### PR TITLE
fix windows build error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -251,7 +251,7 @@ class Peco {
   }
 
   resolvePecoDir(...args) {
-    return path.join(this.options.baseDir, '.peco', ...args)
+    return path.posix.join(this.options.baseDir, '.peco', ...args)
   }
 
   async getFileData(filepath, stats) {


### PR DESCRIPTION
```
Module build failed: SyntaxError: D:\Project\Js\peco\examples\blog\.peco\router.js: Octal literal in strict mode (40:41)

  38 |         component: async () => {
  39 |           const [page, LayoutManager] = await Promise.all([
> 40 |               import('dot-peco\data\page\2.json'),
     |                                          ^
  41 |               import('@layout-manager').then(v => v.default)
  42 |             ])
  43 |             return {
    at Parser.raise (D:\Project\Js\peco\node_modules\@babel\core\node_modules\babylon\lib\index.js:779:15)
```

