### PR TITLE
fix windows slash error

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "promise-polyfill": "^7.1.2",
     "register-service-worker": "^1.2.0",
     "resolve-from": "^4.0.0",
+    "slash": "^2.0.0",
     "time-fix-plugin": "^2.0.1",
     "toml": "^2.3.3",
     "url-loader": "^1.0.1",

--- a/plugins/google-analytics/index.js
+++ b/plugins/google-analytics/index.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const slash = require('slash')
 
 module.exports = class GoogleAnalyticsPlugin {
   constructor(options) {
@@ -14,6 +15,8 @@ module.exports = class GoogleAnalyticsPlugin {
       ])
     })
 
-    api.enhanceAppFiles.add(path.join(__dirname, 'google-analytics-inject.js'))
+    api.enhanceAppFiles.add(
+      slash(path.join(__dirname, 'google-analytics-inject.js'))
+    )
   }
 }

--- a/plugins/pwa/index.js
+++ b/plugins/pwa/index.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const slash = require('slash')
 
 module.exports = class OfflinePlugin {
   constructor(pwaEnabled) {
@@ -14,7 +15,7 @@ module.exports = class OfflinePlugin {
       ])
     })
 
-    api.enhanceAppFiles.add(path.join(__dirname, 'pwa-inject.js'))
+    api.enhanceAppFiles.add(slash(path.join(__dirname, 'pwa-inject.js')))
 
     api.configureDevServer(app => {
       app.use(require('./noop-sw-middleware')())


### PR DESCRIPTION
same error with windows~

```bash
ERROR in ./examples/blog/.peco/create-app.js
Module not found: Error: Can't resolve 'D:Project
odepecopluginsgoogle-analyticsgoogle-analytics-inject.js' in 'D:\Project\node\peco\examples\blog\.peco'
 @ ./examples/blog/.peco/create-app.js 14:88-166
 @ ./lib/engine/app/client-entry.js
 @ multi ./lib/engine/app/client-entry.js

ERROR in ./examples/blog/.peco/create-app.js
Module not found: Error: Can't resolve 'D:Project
odepecopluginspwapwa-inject.js' in 'D:\Project\node\peco\examples\blog\.peco'
 @ ./examples/blog/.peco/create-app.js 16:64-116
 @ ./lib/engine/app/client-entry.js
 @ multi ./lib/engine/app/client-entry.js

```